### PR TITLE
Add OpenTimestamps writeup to drafts

### DIFF
--- a/draft-documents/README.md
+++ b/draft-documents/README.md
@@ -14,6 +14,7 @@ This is a current list of white papers and specs that are expected to come out o
 | ***Smarter Signatures*** | Christopher A. | Approved Draft | Editor | [link](smarter-signatures.md) | |
 | ***VCTF Use Cases***  | Joe A..  | Drafting    | Authors | -                                                         |  Comments on 6/22                    |
 | ***Finding Identity***  | Marta..  | Drafting    | Authors | -                                                         |  Early stage                    |
+| ***OpenTimestamps***  | Peter T..  | Drafting    | Authors | [link](https://petertodd.org/2016/opentimestamps-announcement) |  Pending reformat from blog post |
 
 Once you have proceeded through initial drafts, please lock any versions of your document in Google docs or elsewhere, and transfer your first draft here, to this Github folder, preferably as a MD document. (If you're unable to do so, an alternative is to contact Shannon with your final Doc, and he can get it transferred into MD.) From there, all continuing work should be done with the Github document as the master copy.
 


### PR DESCRIPTION
Already have a fairly complete writeup, but it's written as a blog post rather than as a self-contained paper.
